### PR TITLE
Fix another forgotten slash in eix-sync which broke hook support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 # ChangeLog for eix - Ebuild IndeX for portage
 
 *eix-0.31.4
+	Thomas D. <whissi at whissi.de>:
+	- Fix forgotten slash in eix-sync breaking hooks support (regression
+	  from eix-0.31.3), see
+	  https://bugs.gentoo.org/show_bug.cgi?id=565504
+
 	Martin Väth <martin at mvath.de>:
 	- Fix typo in eix-sync (regression from eix-0.31.3)
 

--- a/src/eix-sync.in
+++ b/src/eix-sync.in
@@ -103,7 +103,7 @@ DoExecute() {
 	for curr_cmd
 	do	set +f
 		! $printcmd || PrintCmd "$curr_cmd"
-		$dryrun || eval "$curr_cmd" || WarnOrDie
+		$dryrun || eval "$curr_cmd" || WarnOrDie \
 			"`eval_pgettext 'eix-sync' \
 				'Something went wrong with ${curr_cmd}'`"
 	done


### PR DESCRIPTION
Commit 4f9cc48ac43c9932db03ba7640d7139cafc4689d broke hook support in `eix-sync` due to a missing blackslash.

Bug: https://bugs.gentoo.org/show_bug.cgi?id=565504