### PR TITLE
Improve performance of StringHash by using an unordered map

### DIFF
--- a/src/eixTk/stringutils.h
+++ b/src/eixTk/stringutils.h
@@ -468,7 +468,7 @@ class StringHash : public WordVec {
 
 	private:
 		bool hashing, finalized;
-		typedef std::map<std::string, StringHash::size_type> StrSizeMap;
+		typedef UNORDERED_MAP<std::string, StringHash::size_type> StrSizeMap;
 		StrSizeMap str_map;
 		static StringHash *comparison_this;
 		static bool frequency_comparison(const std::string a, const std::string b);


### PR DESCRIPTION
In general, if key order is unimportant, hashmaps are a better choice than treemaps because hashmaps are usually faster than treemaps.

A measurement on my machine shows that performance of eix-update improved from 3.5 to 2.6 seconds.

I did not fully check whether code using StringHash::str_map requires lexicographic ordering. It does not seem to require it, but I leave the final decision to you because you know the code better than me.

Please merge.
Thanks.