### PR TITLE
Improve eix-update performance

### DIFF
--- a/src/eixTk/stringlist.cc
+++ b/src/eixTk/stringlist.cc
@@ -101,6 +101,6 @@ void StringList::push_back(std::string&& s) {
 		ptr->usage = 1;
 #endif
 	}
-	ptr->push_back(s);
+	ptr->push_back(std::move(s));
 }
 #endif

--- a/src/eixTk/stringlist.h
+++ b/src/eixTk/stringlist.h
@@ -65,7 +65,7 @@ class StringListContent {
 
 #ifdef HAVE_MOVE
 		void push_back(std::string&& s) {
-			m_list.PUSH_BACK(s);
+			m_list.PUSH_BACK(std::move(s));
 		}
 #endif
 

--- a/src/eixTk/stringutils.h
+++ b/src/eixTk/stringutils.h
@@ -484,7 +484,7 @@ template<typename T> inline static void push_back(std::vector<T> *v, const T& e)
 }
 #ifdef HAVE_MOVE
 template<typename T> inline static void push_back(std::vector<T> *v, T&& e) {
-	v->PUSH_BACK(e);
+	v->PUSH_BACK(std::move(e));
 }
 #endif
 
@@ -496,7 +496,7 @@ template<typename T> inline static void push_back(std::set<T> *s, const T& e) {
 }
 #ifdef HAVE_MOVE
 template<typename T> inline static void push_back(std::set<T> *s, T&& e) {
-	s->INSERT(e);
+	s->INSERT(std::move(e));
 }
 #endif
 
@@ -509,7 +509,7 @@ template<typename T> inline static void push_back(UNORDERED_SET<T> *s, const T& 
 }
 #ifdef HAVE_MOVE
 template<typename T> inline static void push_back(UNORDERED_SET<T> *s, T&& e) {
-	s->INSERT(e);
+	s->INSERT(std::move(e));
 }
 #endif
 #endif  // HAVE_UNORDERED_SET


### PR DESCRIPTION
Use SSE2 instructions to improve performance of find_first_of()
by about 40%, which in turn improves performance of eix-update
by about 20%. In case the CPU/compiler does not support SSE2,
this patch isn't causing a performance drop. If/when the
performance of std::string::find_first_of() improves,
the custom find_first_of() function can be removed.
Tested with GCC 10.2.0	and clang 10.0.1.

Also add missing std::move to slightly improve performance.

Please merge. Thanks.