### PR TITLE
Silence layman repo listing in eix-remote when in quiet mode

### DIFF
--- a/src/eix-remote.sh.in
+++ b/src/eix-remote.sh.in
@@ -334,7 +334,10 @@ AddArchive() {
 		$excluderemote && \
 			test -r "$local_layman/$name" && continue
 		virtual=layman/$name
-		printf '%s -> %s\n' "$virtual" "${l:-no repo-name}"
+		if $verbose
+		then
+			printf '%s -> %s\n' "$virtual" "${l:-no repo-name}"
+		fi
 		AddMethod "$virtual" "$i"
 		AddOverlays "$virtual"
 		[ -n "${l:++}" ] && AddRepoName "$virtual" "$l"


### PR DESCRIPTION
Hello.
This small PR silences the (quite verbose) layman repositories listing when `eix-remote` is being run in quiet mode.