### PR TITLE
Do not emit error if there is no $HOME environment variable

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: eix\n"
 "Report-Msgid-Bugs-To: https://github.com/vaeth/eix/issues/\n"
 "POT-Creation-Date: 2020-05-02 19:18+0200\n"
-"PO-Revision-Date: 2021-06-05 16:53+0200\n"
+"PO-Revision-Date: 2021-07-09 12:18+0200\n"
 "Last-Translator: Martin Väth <martin@mvath.de>\n"
 "Language-Team: German\n"
 "Language: de\n"
@@ -8367,10 +8367,6 @@ msgstr "doppeltes ELSE"
 #: src/eixrc/eixrc.cc
 msgid "IF without FI"
 msgstr "IF ohne FI"
-
-#: src/eixrc/eixrc.cc
-msgid "no $HOME found in environment."
-msgstr "Kein $HOME in der Umgebung."
 
 #: src/eixrc/eixrc.cc
 #, c-format

--- a/po/ru.po
+++ b/po/ru.po
@@ -11,7 +11,7 @@ msgstr ""
 "Project-Id-Version: eix\n"
 "Report-Msgid-Bugs-To: https://github.com/vaeth/eix/issues/\n"
 "POT-Creation-Date: 2020-05-02 19:18+0200\n"
-"PO-Revision-Date: 2021-06-05 16:49+0200\n"
+"PO-Revision-Date: 2021-07-09 12:18+0200\n"
 "Last-Translator: Artem Vorotnikov <skybon@gmail.com>\n"
 "Language-Team: русский <>\n"
 "Language: ru\n"
@@ -7215,10 +7215,6 @@ msgstr "двойной ELSE"
 #: src/eixrc/eixrc.cc
 msgid "IF without FI"
 msgstr "IF без FI"
-
-#: src/eixrc/eixrc.cc
-msgid "no $HOME found in environment."
-msgstr "$HOME не найден в environment."
 
 # fuzzy (only punctation changed)
 #: src/eixrc/eixrc.cc

--- a/src/eixrc/eixrc.cc
+++ b/src/eixrc/eixrc.cc
@@ -422,9 +422,7 @@ void EixRc::read_undelayed(WordUnorderedSet *has_delayed) {
 
 		// override with EIX_USERRC
 		char *home(std::getenv("HOME"));
-		if(unlikely(home == NULLPTR)) {
-			eix::say_error(_("no $HOME found in environment."));
-		} else {
+		if(home) {
 			string eixrc(home);
 			eixrc.append(EIX_USERRC);
 			if(unlikely(!rc.read(eixrc.c_str(), &errtext, true))) {


### PR DESCRIPTION
Using eix in a systemd unit would display this error message on every
invocation of eix. This commit removes the "no $HOME" error message,
as it is largely unnecessary and hence mostly causes noise.