### PR TITLE
remove ATTRIBUTE_SIGNAL

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -118,9 +118,6 @@
 /* Define if __attribute__ ((pure)) can be used */
 #undef HAVE_ATTRIBUTE_PURE
 
-/* Define if __attribute__ ((signal)) can be used */
-#undef HAVE_ATTRIBUTE_SIGNAL
-
 /* Define if [[noreturn]] can be used */
 #undef HAVE_C11ATTRIBUTE_NORETURN
 

--- a/configure.ac
+++ b/configure.ac
@@ -1246,31 +1246,6 @@ AS_IF([$attr_afallthrough],
 		[1],
 		[Define if __attribute__ ((fallthrough)) can be used])])
 
-# Check if __attribute__ ((signal)) works
-AC_MSG_CHECKING([whether __attribute__ ((signal)) can be used])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[
-#include <csignal>
-__attribute__ ((signal)) void my_sig_handler(int sig);
-class my_int {
-friend __attribute__ ((signal)) void my_sig_handler(int sig);
-private:	static int i;
-		static void set(int s) { i=s; }
-};
-int my_int::i;
-void my_sig_handler(int sig)
-{ my_int::set(sig); }
-		]], [[
-	signal(SIGTERM, my_sig_handler);
-		]])],
-		[MV_MSG_RESULT([yes])
-		AS_VAR_SET([attr_signal], [:])],
-		[MV_MSG_RESULT([no])
-		AS_VAR_SET([attr_signal], [false])])
-AS_IF([$attr_signal],
-	[AC_DEFINE([HAVE_ATTRIBUTE_SIGNAL],
-		[1],
-		[Define if __attribute__ ((signal)) can be used])])
-
 # Check if __attribute__ ((const)) works
 AC_MSG_CHECKING([whether __attribute__ ((const)) can be used])
 MV_RUN_IFELSE_LINK([AC_LANG_PROGRAM([[

--- a/meson.build
+++ b/meson.build
@@ -1082,26 +1082,6 @@ message('__attribute__ ((fallthrough)) ' + attr_afallthrough.to_string())
 conf.set('HAVE_ATTRIBUTE_AFALLTHROUGH', attr_afallthrough,
 	description : 'Define if __attribute__ ((fallthrough)) can be used')
 
-attr_signal = cxx.links('''
-#include <csignal>
-__attribute__ ((signal)) void my_sig_handler(int sig);
-class my_int {
-friend __attribute__ ((signal)) void my_sig_handler(int sig);
-private:	static int i;
-		static void set(int s) { i=s; }
-};
-int my_int::i;
-void my_sig_handler(int sig)
-{ my_int::set(sig); }
-int main() {
-	signal(SIGTERM, my_sig_handler);
-	return 0;
-}
-''', args : flags_fatal)
-message('__attribute__ ((signal)) ' + attr_signal.to_string())
-conf.set('HAVE_ATTRIBUTE_SIGNAL', attr_signal,
-	description : 'Define if __attribute__ ((signal)) can be used')
-
 attr_const = cxx.links('''
 class b {
 public:

--- a/src/cache/common/ebuild_exec.h
+++ b/src/cache/common/ebuild_exec.h
@@ -24,10 +24,10 @@ class BasicCache;
 class Package;
 class Version;
 
-ATTRIBUTE_SIGNAL void ebuild_sig_handler(int sig);
+void ebuild_sig_handler(int sig);
 
 class EbuildExec {
-		ATTRIBUTE_SIGNAL friend void ebuild_sig_handler(int sig);
+		friend void ebuild_sig_handler(int sig);
 		friend class EbuildExecSettings;
 
 	private:

--- a/src/eixTk/attribute.h
+++ b/src/eixTk/attribute.h
@@ -22,12 +22,6 @@
 #endif  // HAVE_ATTRIBUTE_NORETURN
 #endif  // HAVE_C11ATTRIBUTE_NORETURN
 
-#ifdef HAVE_ATTRIBUTE_SIGNAL
-#define ATTRIBUTE_SIGNAL __attribute__ ((signal))
-#else
-#define ATTRIBUTE_SIGNAL
-#endif
-
 #ifdef HAVE_ATTRIBUTE_CONST
 #define ATTRIBUTE_CONST __attribute__ ((const))
 #else

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -116,7 +116,7 @@ The name under which we have been called.
 **/
 const char *program_name;
 
-ATTRIBUTE_SIGNAL ATTRIBUTE_NORETURN static void sig_handler(int sig);
+ATTRIBUTE_NORETURN static void sig_handler(int sig);
 ATTRIBUTE_NONNULL_ static void sanitize_filename(string *s);
 
 /**


### PR DESCRIPTION
this is only needed on AVR, which was dropped in kernel 4.12 and the ISA is since dead (vendor just sells some Cortex-M instead)

This caused warnings with gcc and clang, and it seems like an unknown attribute followed by a real one is an error in clang, as the snippet

`__attribute__ (signal) [[noreturn]] void func() {}`

fails to compile on clang - sig_handler in main.cc was one such function.