### PR TITLE
manpage: Clarify purpose of eix-remote, -R and -Z options.

### DIFF
--- a/manpage/de-eix.1.in
+++ b/manpage/de-eix.1.in
@@ -78,6 +78,7 @@ B<eix-test-obsolete> ist ein Skript, das B<eix> mehrmals aufruft, um die Ausgabe
 
 B<eix-remote> kann eine Eix-Datenbank von einem externen Server syncen und ihn zum
 lokalen Cache hinzufügen und wieder entfernen.
+Dies kann verwendet werden, um eine lokale Datenbank mit Paketen in allen registrierten Repositorys/Overlays zu erstellen, nicht nur denen in lokal installierten Overlays.
 Falls nicht anders konfiguriert, benutzt es ein separates Datenbankfile.
 Bei dieser Vorgabe sollten Sie regelmäig B<eix-remote add1> und/oder <eix-remote add2> nach <eix-update>
 aufrufen, so dass das separate Cachefile mit der Hauptdatenbank synchron ist.
@@ -442,13 +443,13 @@ Diese Dateien (und wie ihre Namen geändert werden können) wird später beschri
 .TP
 .BR -R ", " --remote
 Benutzt den Wert von EIX_REMOTE1 als Namen für das Cachefile.
-Diese Option sollten Sie benutzen, wenn Sie das Ergebnis von <eix-remote> sehen wollen.
+Diese Option sollten Sie benutzen, wenn Sie Pakete im Cache sehen möchten, die von B<eix-remote> erstellt und synchronisiert wurden.
 Sie können diese Option als Standardeinstellung aktivieren, indem Sie B<REMOTE_DEFAULT=1> setzen.
 
 .TP
 .BR -Z ", " --remote2
 Benutzt den Wert von EIX_REMOTE2 als Namen für das Cachefile.
-Diese Option sollten Sie benutzen, wenn Sie das Ergebnis von <eix-remote> sehen wollen.
+Diese Option sollten Sie benutzen, wenn Sie Pakete im Cache sehen möchten, die von B<eix-remote> erstellt und synchronisiert wurden.
 Sie können diese Option als Standardeinstellung aktivieren, indem Sie B<REMOTE_DEFAULT=2> setzen.
 
 .TP

--- a/manpage/en-eix.1.in
+++ b/manpage/en-eix.1.in
@@ -80,7 +80,10 @@ B<eix-test-obsolete> is a script which calls B<eix> several times to display
 the output of B<eix -tTc> in a more organized manner.
 
 B<eix-remote> can sync an eix database from an external server and
-add/remove it to the current database. By default it uses a separate cachefile.
+add/remove it to the current database. This can be used to create a
+local database of packages in all registered repositories/overlays,
+not just those in overlays installed locally.
+By default it uses a separate cachefile.
 With this default you should regularly call B<eix-remote add1> and/or B<eix-remote add2> after B<eix-update>
 so that the separate cachefile is synchronized with your main database.
 (If you use B<eix-sync> this is done by default.)
@@ -428,13 +431,15 @@ These files (and how to modify their filenames) are described later.
 .TP
 .BR -R ", " --remote
 Uses the value of B<EIX_REMOTE1> as cache file name.
-Use this option if you want to see what B<eix-remote> produced.
+Use this option if you want to see packages in the cache created
+and synchronized by B<eix-remote>.
 You can make this option the default by setting B<REMOTE_DEFAULT=1>.
 
 .TP
 .BR -Z ", " --remote2
 Uses the value of B<EIX_REMOTE2> as cache file name.
-Use this option if you want to see what B<eix-remote> produced.
+Use this option if you want to see packages in the cache created
+and synchronized by B<eix-remote>.
 You can make this option the default by setting B<REMOTE_DEFAULT=2>.
 
 .TP

--- a/manpage/ru-eix.1.in
+++ b/manpage/ru-eix.1.in
@@ -78,6 +78,8 @@ B<eix-diff> will not work for the first syncing after the upgrade
 B<eix-test-obsolete> - сценарий, несколько раз вызывающий B<eix> для более структурированного вывода B<eix -tTc>.
 
 B<eix-remote> позволяет синхронизировать текущую базу eix с внешним сервером, добавляя/удаляя из неё данные.
+Это можно использовать для создания локальной базы данных пакетов во всех зарегистрированных репозиториях/оверлеях, а не только в оверлеях, установленных локально.
+По умолчанию он использует отдельный кэш-файл.
 With this default you should regularly call B<eix-remote add1> and/or B<eix-remote add2> after B<eix-update>
 so that the separate cachefile is synchronized with your main database.
 (If you use B<eix-sync> this is done by default.)
@@ -425,13 +427,13 @@ These files (and how to modify their filenames) are described later.
 .TP
 .BR -R ", " --remote
 Uses the value of B<EIX_REMOTE1> as cache file name.
-Use this option if you want to see what B<eix-remote> produced.
+Use this option if you want to see packages in the cache created and synchronized by B<eix-remote>.
 You can make this option the default by setting B<REMOTE_DEFAULT=1>.
 
 .TP
 .BR -Z ", " --remote2
 Uses the value of B<EIX_REMOTE2> as cache file name.
-Use this option if you want to see what B<eix-remote> produced.
+Use this option if you want to see packages in the cache created and synchronized by B<eix-remote>.
 You can make this option the default by setting B<REMOTE_DEFAULT=2>.
 
 .TP


### PR DESCRIPTION
Further to [this comment on the forums](https://forums.gentoo.org/viewtopic-p-8813673.html#8813673), i've made some changes to the man page to (hopefully) clarify the purpose of eix-remote, and the `-R` and `-Z` options.

My German is limited, and i can only slowly read Cyrllic, let alone Russian in particular, so i've used Google Translate to translate my English text, with some tweaks to the German to match existing phrasing elsewhere on the page.

Please let me know of any changes i need to make.