### PR TITLE
On issue 123 - Changed ^ to groff's escape sequence \(ha

### DIFF
--- a/manpage/de-eix.1.in
+++ b/manpage/de-eix.1.in
@@ -989,7 +989,7 @@ Vorsicht bei der Übergabe des Suchmusters in einer Shell (Quoting!).
 .TP
 .BR -r ", " --regex
 Das Suchmuster ist ein regulärer Ausdruck (ohne Beachtung der Großschreibung).
-Nur ein Teilstring muss passen (außer wenn ^ oder $ benutzt werden).
+Nur ein Teilstring muss passen (außer wenn \(ha oder $ benutzt werden).
 Das leere Suchmuster passt auf alles.
 Weitere Informationen finden sich in
 .BR regex (7).
@@ -1102,7 +1102,7 @@ Dies ist Version 3.14p, die in den Slot "GNAT-3.14p" installiert wird.
 .B 2.0.0_rc1-r6
 Dies ist Version 2.0.0_rc1-r6, und der SLOT ist leer oder "0".
 .TP
-.B 1.0*ilvs^fmpbstuidP{tbz2,gpkg:3,pak:2}
+.B 1.0*ilvs\(hafmpbstuidP{tbz2,gpkg:3,pak:2}
 Dies ist Version 1.0, und gesetzt sind
 PROPERTIES="interactive live virtual set" sowie
 RESTRICT="fetch mirror primaryuri binchecks strip test userpriv installsources bindist parallel".
@@ -1110,7 +1110,7 @@ Darüberhinaus existiert eine *.tbz2, drei *.gpkg.tar und zwei *.xpak-Dateien
 (Binärpakete ohne bzw. mit FEATURES=binpkg-multi-instance bzw, FEATURES=gpkg)
 für diese Version in B<PKGDIR>.
 .TP
-.B 5.0-r3(5.0R3)^f "   oder   " 5.0-r3:5.0R3^f
+.B 5.0-r3(5.0R3)\(haf "   oder   " 5.0-r3:5.0R3\(haf
 Dies ist Version 5.0-r3, die in Slot 5.0R3 installiert wird, und die RESTRICT=fetch hat.
 
 .SS Maskierung

--- a/manpage/en-eix.1.in
+++ b/manpage/en-eix.1.in
@@ -973,7 +973,7 @@ shell from intercepting any wildcards).
 .TP
 .BR -r ", " --regex
 pattern is a regexp, ignoring case.
-Only a substring must be matched (unless ^ or $ are used);
+Only a substring must be matched (unless \(ha or $ are used);
 the empty pattern matches everything.
 For further information, please read
 .BR regex (7).
@@ -1081,7 +1081,7 @@ This is version 3.14p which will be installed into the slot "GNAT-3.14p".
 .B 2.0.0_rc1-r6
 This is version 2.0.0_rc1-r6, and SLOT is either empty or "0".
 .TP
-.B 1.0*ilvs^fmpbstuidP{tbz2,gpkg:3,pak:2}
+.B 1.0*ilvs\(hafmpbstuidP{tbz2,gpkg:3,pak:2}
 This is version 1.0 which is subject to
 PROPERTIES="interactive live virtual set" as well as
 RESTRICT="fetch mirror primaryuri binchecks strip test userpriv installsources bindist parallel"
@@ -1089,7 +1089,7 @@ Moreover, a *.tbz2, three *.gpkg.tar, and two *.xpak files (binary packages with
 FEATURES=binpkg-multi-instance or BINPKG_FORMAT=gpkg, respectively) exist for that version
 in B<PKGDIR>.
 .TP
-.B 5.0-r3(5.0R3)^f "    or    " 5.0-r3:5.0R3^f
+.B 5.0-r3(5.0R3)\(haf "    or    " 5.0-r3:5.0R3\(haf
 This is version 5.0-r3 which will be installed into SLOT 5.0R3 and has
 fetch restrictions.
 

--- a/manpage/ru-eix.1.in
+++ b/manpage/ru-eix.1.in
@@ -967,7 +967,7 @@ shell from intercepting any wildcards).
 .TP
 .BR -r ", " --regex
 pattern is a regexp, ignoring case.
-Only a substring must be matched (unless ^ or $ are used);
+Only a substring must be matched (unless \(ha or $ are used);
 the empty pattern matches everything.
 For further information, please read
 .BR regex (7).
@@ -1075,7 +1075,7 @@ This is version 3.14p which will be installed into the slot "GNAT-3.14p".
 .B 2.0.0_rc1-r6
 This is version 2.0.0_rc1-r6, and SLOT is either empty or "0".
 .TP
-.B 1.0*ilvs^fmpbstuidP{tbz2,gpkg:3,pak:2}
+.B 1.0*ilvs\(hafmpbstuidP{tbz2,gpkg:3,pak:2}
 This is version 1.0 which is subject to
 PROPERTIES="interactive live virtual set" as well as
 RESTRICT="fetch mirror primaryuri binchecks strip test userpriv installsources bindist parallel"
@@ -1083,7 +1083,7 @@ Moreover, a *.tbz2, three *.gpkg.tar, and two *.xpak files (binary packages with
 FEATURES=binpkg-multi-instance or BINPKG_FORMAT=gpkg, respectively) exist for that version
 in B<PKGDIR>.
 .TP
-.B 5.0-r3(5.0R3)^f "    or    " 5.0-r3:5.0R3^f
+.B 5.0-r3(5.0R3)\(haf "    or    " 5.0-r3:5.0R3\(haf
 This is version 5.0-r3 which will be installed into SLOT 5.0R3 and has
 fetch restrictions.
 


### PR DESCRIPTION
 Changes to be committed:
	modified:   manpage/de-eix.1.in
	modified:   manpage/en-eix.1.in
	modified:   manpage/ru-eix.1.in

 Changed **^** (caret) to groff's escape sequence **\\(ha**.

The ascii **^** (caret sign) was changed in favor of groff's escape sequence **\\\(ha** as noted in `man 7 groff_man_style`, **_NOTE_** section. These changes are intended to enforce the author's intention to reproduce the correct ^ (caret) sign representation across encodings instead of a modified circumflex sign done by groff's due to aesthetical reasons.