### PR TITLE
eix-postsync.sh.in: Attempt to copy old database only when it exists

### DIFF
--- a/src/eix-postsync.sh.in
+++ b/src/eix-postsync.sh.in
@@ -23,6 +23,7 @@ ReadFunctions
 ReadVar eixcache EIX_CACHEFILE
 ReadVar eixprevious EIX_PREVIOUS
 CopyToPrevious() {
+	[ -e "$eixcache" ] || return
 	StatusInfo "`eval_pgettext 'eix-sync' \
 			'Copying old database to ${eixprevious}'`" \
 		"`eval_pgettext 'Statusline eix-sync' \


### PR DESCRIPTION
EixUpdate doesn't execute because `cp` calls `die`.