### PR TITLE
eix-postsync: fix initial invocation of eix-postsync

### DIFF
--- a/src/eix-postsync.sh.in
+++ b/src/eix-postsync.sh.in
@@ -23,6 +23,8 @@ ReadFunctions
 ReadVar eixcache EIX_CACHEFILE
 ReadVar eixprevious EIX_PREVIOUS
 CopyToPrevious() {
+	# return without failure if $eixcache has not yet been created
+	test -f "$eixcache" || return 0
 	StatusInfo "`eval_pgettext 'eix-sync' \
 			'Copying old database to ${eixprevious}'`" \
 		"`eval_pgettext 'Statusline eix-sync' \


### PR DESCRIPTION
On the initial invocation of eix-postsync, $eixcache has not yet created. This would result in a failure, because CopyToPrevious() assumed that $eixcache exists.

To fix this, we add an early exit if $eixcache does not yet exist.

Bug: https://bugs.gentoo.org/945989