### PR TITLE
Rectify path to remote2 cache file in man pages

### DIFF
--- a/manpage/en-eix.1.in
+++ b/manpage/en-eix.1.in
@@ -2240,7 +2240,7 @@ usually B<%{EPREFIX}@EIX_PREVIOUS@>
 The eix cache used when B<-R> or B<-Z> is in effect.
 If the string is nonempty, eix-remote uses this file for the output.
 The default value is B<%{EPREFIX}@EIX_REMOTECACHEFILE1@>
-or B<%{EPREFIX}@EIX_REMOTECACHEFILE1@>, respectively.
+or B<%{EPREFIX}@EIX_REMOTECACHEFILE2@>, respectively.
 
 .TP
 .BR REMOTE_DEFAULT " " (integer)

--- a/manpage/ru-eix.1.in
+++ b/manpage/ru-eix.1.in
@@ -2234,7 +2234,7 @@ usually B<%{EPREFIX}@EIX_PREVIOUS@>
 The eix cache used when B<-R> or B<-Z> is in effect.
 If the string is nonempty, eix-remote uses this file for the output.
 The default value is B<%{EPREFIX}@EIX_REMOTECACHEFILE1@>
-or B<%{EPREFIX}@EIX_REMOTECACHEFILE1@>, respectively.
+or B<%{EPREFIX}@EIX_REMOTECACHEFILE2@>, respectively.
 
 .TP
 .BR REMOTE_DEFAULT " " (integer)


### PR DESCRIPTION
The German man page already had it right, but the English and Russian ones were referring to a wrong variable, which is substituted by configure.

The generated man pages were pointing to the same file twice, for the remote as well as the second remote cache.